### PR TITLE
Add Yo Protocol Liquidity Module

### DIFF
--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -1,0 +1,34 @@
+from templates.liquidity_module import LiquidityModule, Token
+from typing import Dict, Optional
+from decimal import Decimal
+
+class MyProtocolLiquidityModule(LiquidityModule):
+    def get_amount_out(
+        self, 
+        pool_states: Dict, 
+        fixed_parameters: Dict,
+        input_token: Token, 
+        output_token: Token,
+        input_amount: int, 
+    ) -> tuple[int | None, int | None]:
+        # Implement logic to calculate output amount given input amount
+        pass
+
+    def get_amount_in(
+        self, 
+        pool_state: Dict, 
+        fixed_parameters: Dict,
+        input_token: Token,
+        output_token: Token,
+        output_amount: int
+    ) -> tuple[int | None, int | None]:
+        # Implement logic to calculate required input amount given output amount
+        pass
+
+    def get_apy(self, pool_state: Dict) -> Decimal:
+        # Implement APY calculation logic
+        pass
+
+    def get_tvl(self, pool_state: Dict, token: Optional[Token] = None) -> Decimal:
+        # Implement TVL calculation logic
+        pass

--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -88,10 +88,10 @@ class YoProtocolLiquidityModule(LiquidityModule):
         """
 
         currentSharePrice = Decimal(pool_state['currentSharePrice'])
-        firstSharePrice = Decimal(pool_state['firstSharePrice'])
-        uptimeDays = Decimal(pool_state['uptimeDays'])
+        originSharePrice = Decimal(pool_state['originSharePrice'])
+        days = Decimal(pool_state['days'])
 
-        return (currentSharePrice - firstSharePrice) / Constant.ETHER / uptimeDays * Decimal(365) * Decimal(100)
+        return (currentSharePrice - originSharePrice) / Constant.ETHER / days * Decimal(365) * Decimal(100)
 
     def get_tvl(self, pool_state: Dict, token: Optional[Token] = None) -> Decimal:
         """

--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -34,7 +34,7 @@ class YoProtocolLiquidityModule(LiquidityModule):
         """
         Convert a value from Wei to Ether denomination using the constant ETHER.
         """
-        return Decimal(amount) / Constant.ETHER  # Fix typo in Constant
+        return Decimal(amount) / Constant.ETHER
 
     def get_amount_out(
         self, 

--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -1,14 +1,44 @@
 from templates.liquidity_module import LiquidityModule, Token
 from typing import Dict, Optional
 from decimal import Decimal
+import math
 
 class Constant:
     ETHER = Decimal('1e18')
+    OPTIMISM_WETH = "0x4200000000000000000000000000000000000006"
 
 class YoProtocolLiquidityModule(LiquidityModule):
+    def _convert_to_assets(self, pool_state: Dict, fixed_parameters: Dict, amount: int) -> int:
+        """
+        Convert a given amount of shares to the equivalent amount of underlying assets using the pool state and fixed parameters.
+        Formula: floor(amount * (totalAssets + 1) / (totalSupply + 10 ** decimals))
+        """
+        totalAssets = pool_state["totalAssets"]
+        totalSupply = pool_state["totalSupply"]
+        decimals = fixed_parameters["decimals"]
+
+        return math.floor(amount * (totalAssets + 1) / (totalSupply + 10 ** decimals))
+
+    def _convert_to_shares(self, pool_state: Dict, fixed_parameters: Dict, amount: int) -> int:
+        """
+        Convert a given amount of underlying assets to the equivalent amount of shares using the pool state and fixed parameters.
+        Formula: floor(amount * (totalSupply + 10 ** decimals) / (totalAssets + 1))
+        """
+        totalAssets = pool_state["totalAssets"]
+        totalSupply = pool_state["totalSupply"]
+        decimals = fixed_parameters["decimals"]
+
+        return math.floor(amount * (totalSupply + 10 ** decimals) / (totalAssets + 1))
+
+    def _wei_to_ether(self, amount: int) -> Decimal:
+        """
+        Convert a value from Wei to Ether denomination using the constant ETHER.
+        """
+        return Decimal(amount) / Constant.ETHER  # Fix typo in Constant
+
     def get_amount_out(
         self, 
-        pool_states: Dict, 
+        pool_state: Dict, 
         fixed_parameters: Dict,
         input_token: Token, 
         output_token: Token,
@@ -17,6 +47,17 @@ class YoProtocolLiquidityModule(LiquidityModule):
         """
         Returns the amount of underlying asset required to transfer to get output_amount shares in Ether denomination. (using OZ ERC4626 convertToAssets function)
         """
+
+        output_amount = 0
+
+        if input_token.address == fixed_parameters["underlyingTokenAddress"]:
+            output_amount = self._convert_to_assets(pool_state, fixed_parameters, input_amount)
+        elif input_token.address == fixed_parameters["sharesTokenAddress"]:
+            output_amount = self._convert_to_shares(pool_state, fixed_parameters, input_amount)
+        else:
+            raise ValueError("Invalid token address. Must be either underlyingTokenAddress or sharesTokenAddress.")
+        
+        return (output_amount, None)
 
     def get_amount_in(
         self, 
@@ -29,7 +70,17 @@ class YoProtocolLiquidityModule(LiquidityModule):
         """
         Returns the amount of underlying asset received from input_amount of shares in Ether denomination. (using OZ ERC4626 convertToShares function)
         """
-        pass
+        
+        output_amount = 0
+
+        if input_token.address == fixed_parameters["underlyingTokenAddress"]:
+            output_amount = self._convert_to_shares(pool_state, fixed_parameters, output_amount)
+        elif input_token.address == fixed_parameters["sharesTokenAddress"]:
+            output_amount = self._convert_to_assets(pool_state, fixed_parameters, output_amount)
+        else:
+            raise ValueError("Invalid token address. Must be either underlyingTokenAddress or sharesTokenAddress.")
+        
+        return (output_amount, None)
 
     def get_apy(self, pool_state: Dict) -> Decimal:
         """
@@ -53,8 +104,9 @@ class YoProtocolLiquidityModule(LiquidityModule):
             raise ValueError("Token address does not match the underlying token address in the pool state.")
         
         tvl = 0
+        
         # write access is only on Base, and yoETH uses WETH as underlying token
-        if token.address == "0x4200000000000000000000000000000000000006":
+        if token.address == Constant.OPTIMISM_WETH:
             tvl = totalAssets / Constant.ETHER
         else:
             tvl = totalAssets * token.reference_price / Constant.ETHER

--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -2,7 +2,10 @@ from templates.liquidity_module import LiquidityModule, Token
 from typing import Dict, Optional
 from decimal import Decimal
 
-class MyProtocolLiquidityModule(LiquidityModule):
+class Constant:
+    ETHER = Decimal('1e18')
+
+class YoProtocolLiquidityModule(LiquidityModule):
     def get_amount_out(
         self, 
         pool_states: Dict, 
@@ -11,8 +14,9 @@ class MyProtocolLiquidityModule(LiquidityModule):
         output_token: Token,
         input_amount: int, 
     ) -> tuple[int | None, int | None]:
-        # Implement logic to calculate output amount given input amount
-        pass
+        """
+        Returns the amount of underlying asset required to transfer to get output_amount shares in Ether denomination. (using OZ ERC4626 convertToAssets function)
+        """
 
     def get_amount_in(
         self, 
@@ -22,13 +26,36 @@ class MyProtocolLiquidityModule(LiquidityModule):
         output_token: Token,
         output_amount: int
     ) -> tuple[int | None, int | None]:
-        # Implement logic to calculate required input amount given output amount
+        """
+        Returns the amount of underlying asset received from input_amount of shares in Ether denomination. (using OZ ERC4626 convertToShares function)
+        """
         pass
 
     def get_apy(self, pool_state: Dict) -> Decimal:
-        # Implement APY calculation logic
-        pass
+        """
+        Returns the APY of the pool in decimal percentage.
+        """
+
+        currentSharePrice = Decimal(pool_state['currentSharePrice'])
+        firstSharePrice = Decimal(pool_state['firstSharePrice'])
+        uptimeDays = Decimal(pool_state['uptimeDays'])
+
+        return (currentSharePrice - firstSharePrice) / Constant.ETHER / uptimeDays * Decimal(365) * Decimal(100)
 
     def get_tvl(self, pool_state: Dict, token: Optional[Token] = None) -> Decimal:
-        # Implement TVL calculation logic
-        pass
+        """
+        Returns the total value locked (TVL) in the pool in Ether denomination.
+        """
+        
+        totalAssets = Decimal(pool_state['totalAssets'])
+
+        if token.address != pool_state['underlyingTokenAddress']:
+            raise ValueError("Token address does not match the underlying token address in the pool state.")
+        
+        tvl = 0
+        # write access is only on Base, and yoETH uses WETH as underlying token
+        if token.address == "0x4200000000000000000000000000000000000006":
+            tvl = totalAssets / Constant.ETHER
+        else:
+            tvl = totalAssets * token.reference_price / Constant.ETHER
+        return tvl

--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -57,7 +57,7 @@ class YoProtocolLiquidityModule(LiquidityModule):
         else:
             raise ValueError("Invalid token address. Must be either underlyingTokenAddress or sharesTokenAddress.")
         
-        return (output_amount, None)
+        return (None, output_amount)
 
     def get_amount_in(
         self, 
@@ -80,7 +80,7 @@ class YoProtocolLiquidityModule(LiquidityModule):
         else:
             raise ValueError("Invalid token address. Must be either underlyingTokenAddress or sharesTokenAddress.")
         
-        return (input_amount, None)
+        return (None, input_amount)
 
     def get_apy(self, pool_state: Dict) -> Decimal:
         """

--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -96,7 +96,7 @@ class YoProtocolLiquidityModule(LiquidityModule):
     def get_tvl(self, pool_state: Dict, token: Optional[Token] = None) -> Decimal:
         """
         Returns the total value locked (TVL) in the protocol.
-        In terms of the underlying asset.
+        In terms of the underlying asset. In Ether.
         """
         
-        return Decimal(pool_state.get('totalAssets', 0))
+        return self._wei_to_ether(pool_state.get('totalAssets', 0))

--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -91,7 +91,7 @@ class YoProtocolLiquidityModule(LiquidityModule):
         originSharePrice = Decimal(pool_state['originSharePrice'])
         days = Decimal(pool_state['days'])
 
-        return (currentSharePrice - originSharePrice) / Constant.ETHER / days * Decimal(365) * Decimal(100)
+        return self._wei_to_ether(currentSharePrice - originSharePrice) / days * Decimal(100)
 
     def get_tvl(self, pool_state: Dict, token: Optional[Token] = None) -> Decimal:
         """

--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -95,19 +95,7 @@ class YoProtocolLiquidityModule(LiquidityModule):
 
     def get_tvl(self, pool_state: Dict, token: Optional[Token] = None) -> Decimal:
         """
-        Returns the total value locked (TVL) in the pool in Ether denomination.
+        Returns the total value locked (TVL) in the protocol.
         """
         
-        totalAssets = Decimal(pool_state['totalAssets'])
-
-        if token.address != pool_state['underlyingTokenAddress']:
-            raise ValueError("Token address does not match the underlying token address in the pool state.")
-        
-        tvl = 0
-        
-        # write access is only on Base, and yoETH uses WETH as underlying token
-        if token.address == Constant.OPTIMISM_WETH:
-            tvl = totalAssets / Constant.ETHER
-        else:
-            tvl = totalAssets * token.reference_price / Constant.ETHER
-        return tvl
+        return pool_state.get('tvl', 0)

--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -51,9 +51,9 @@ class YoProtocolLiquidityModule(LiquidityModule):
         output_amount = 0
 
         if input_token.address == fixed_parameters["underlyingTokenAddress"]:
-            output_amount = self._convert_to_assets(pool_state, fixed_parameters, input_amount)
-        elif input_token.address == fixed_parameters["sharesTokenAddress"]:
             output_amount = self._convert_to_shares(pool_state, fixed_parameters, input_amount)
+        elif input_token.address == fixed_parameters["sharesTokenAddress"]:
+            output_amount = self._convert_to_assets(pool_state, fixed_parameters, input_amount)
         else:
             raise ValueError("Invalid token address. Must be either underlyingTokenAddress or sharesTokenAddress.")
         

--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -71,16 +71,16 @@ class YoProtocolLiquidityModule(LiquidityModule):
         Returns the amount of underlying asset received from input_amount of shares in Ether denomination. (using OZ ERC4626 convertToShares function)
         """
         
-        output_amount = 0
+        input_amount = 0
 
         if input_token.address == fixed_parameters["underlyingTokenAddress"]:
-            output_amount = self._convert_to_shares(pool_state, fixed_parameters, output_amount)
+            input_amount = self._convert_to_shares(pool_state, fixed_parameters, output_amount)
         elif input_token.address == fixed_parameters["sharesTokenAddress"]:
-            output_amount = self._convert_to_assets(pool_state, fixed_parameters, output_amount)
+            input_amount = self._convert_to_assets(pool_state, fixed_parameters, output_amount)
         else:
             raise ValueError("Invalid token address. Must be either underlyingTokenAddress or sharesTokenAddress.")
         
-        return (output_amount, None)
+        return (input_amount, None)
 
     def get_apy(self, pool_state: Dict) -> Decimal:
         """

--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -15,7 +15,7 @@ class YoProtocolLiquidityModule(LiquidityModule):
         """
         totalAssets = pool_state["totalAssets"]
         totalSupply = pool_state["totalSupply"]
-        decimals = fixed_parameters["decimals"]
+        decimals = fixed_parameters["shareTokenDecimals"]
 
         return math.floor(amount * (totalAssets + 1) / (totalSupply + 10 ** decimals))
 
@@ -26,7 +26,7 @@ class YoProtocolLiquidityModule(LiquidityModule):
         """
         totalAssets = pool_state["totalAssets"]
         totalSupply = pool_state["totalSupply"]
-        decimals = fixed_parameters["decimals"]
+        decimals = fixed_parameters["shareTokenDecimals"]
 
         return math.floor(amount * (totalSupply + 10 ** decimals) / (totalAssets + 1))
 

--- a/modules/yoprotocol_liquidity_module.py
+++ b/modules/yoprotocol_liquidity_module.py
@@ -96,6 +96,7 @@ class YoProtocolLiquidityModule(LiquidityModule):
     def get_tvl(self, pool_state: Dict, token: Optional[Token] = None) -> Decimal:
         """
         Returns the total value locked (TVL) in the protocol.
+        In terms of the underlying asset.
         """
         
-        return pool_state.get('tvl', 0)
+        return Decimal(pool_state.get('totalAssets', 0))

--- a/tests/test_yoprotocol_liquidity_module.py
+++ b/tests/test_yoprotocol_liquidity_module.py
@@ -27,9 +27,22 @@ def sample_pool_state():
         "underlyingTokenAddress": Constant.OPTIMISM_WETH,
         "sharesTokenAddress": "0xSHARES",
         "currentSharePrice": str(2 * 10**18),
-        "originSharePrice": str(1 * 10**18),  # changed key to match source
-        "days": 10,  # changed key to match source
-        "tvl": Decimal("1000.0")  # ensure tvl is present and Decimal
+        "originSharePrice": str(1 * 10**18),
+        "days": 10,
+        "tvl": Decimal("1000.0") 
+    }
+
+@pytest.fixture
+def zero_pool_state():
+    return {
+        "totalAssets": 0,
+        "totalSupply": 0,
+        "underlyingTokenAddress": Constant.OPTIMISM_WETH,
+        "sharesTokenAddress": "0xSHARES",
+        "currentSharePrice": str(0),
+        "originSharePrice": str(0),
+        "days": 1,
+        "tvl": Decimal("0.0")
     }
 
 @pytest.fixture
@@ -69,6 +82,7 @@ def test_get_amount_in_underlying_to_shares(sample_tokens, sample_pool_state, sa
     output_amount = 10 * 10**18
     _, out = module.get_amount_in(sample_pool_state, sample_fixed_parameters, underlying, shares, output_amount)
     assert isinstance(out, int)
+    assert out > 0
 
 def test_get_amount_in_shares_to_underlying(sample_tokens, sample_pool_state, sample_fixed_parameters):
     underlying, shares = sample_tokens
@@ -76,6 +90,7 @@ def test_get_amount_in_shares_to_underlying(sample_tokens, sample_pool_state, sa
     output_amount = 10 * 10**18
     _, out = module.get_amount_in(sample_pool_state, sample_fixed_parameters, shares, underlying, output_amount)
     assert isinstance(out, int)
+    assert out > 0
 
 def test_get_amount_in_invalid_token(sample_tokens, sample_pool_state, sample_fixed_parameters):
     underlying, shares = sample_tokens
@@ -95,4 +110,4 @@ def test_get_tvl(sample_tokens, sample_pool_state):
     module = YoProtocolLiquidityModule()
     tvl = module.get_tvl(sample_pool_state, underlying)
     assert isinstance(tvl, Decimal)
-    assert tvl > 0
+    assert tvl >= 0

--- a/tests/test_yoprotocol_liquidity_module.py
+++ b/tests/test_yoprotocol_liquidity_module.py
@@ -29,7 +29,6 @@ def sample_pool_state():
         "currentSharePrice": str(2 * 10**18),
         "originSharePrice": str(1 * 10**18),
         "days": 10,
-        "tvl": Decimal("1000.0") 
     }
 
 @pytest.fixture
@@ -42,7 +41,6 @@ def zero_pool_state():
         "currentSharePrice": str(0),
         "originSharePrice": str(0),
         "days": 1,
-        "tvl": Decimal("0.0")
     }
 
 @pytest.fixture

--- a/tests/test_yoprotocol_liquidity_module.py
+++ b/tests/test_yoprotocol_liquidity_module.py
@@ -48,7 +48,7 @@ def zero_pool_state():
 @pytest.fixture
 def sample_fixed_parameters():
     return {
-        "decimals": 18,
+        "shareTokenDecimals": 18,
         "underlyingTokenAddress": Constant.OPTIMISM_WETH,
         "sharesTokenAddress": "0xSHARES"
     }

--- a/tests/test_yoprotocol_liquidity_module.py
+++ b/tests/test_yoprotocol_liquidity_module.py
@@ -27,8 +27,9 @@ def sample_pool_state():
         "underlyingTokenAddress": Constant.OPTIMISM_WETH,
         "sharesTokenAddress": "0xSHARES",
         "currentSharePrice": str(2 * 10**18),
-        "firstSharePrice": str(1 * 10**18),
-        "uptimeDays": 10
+        "originSharePrice": str(1 * 10**18),  # changed key to match source
+        "days": 10,  # changed key to match source
+        "tvl": Decimal("1000.0")  # ensure tvl is present and Decimal
     }
 
 @pytest.fixture
@@ -43,7 +44,7 @@ def test_get_amount_out_underlying_to_shares(sample_tokens, sample_pool_state, s
     underlying, shares = sample_tokens
     module = YoProtocolLiquidityModule()
     input_amount = 10 * 10**18
-    out, _ = module.get_amount_out(sample_pool_state, sample_fixed_parameters, underlying, shares, input_amount)
+    _, out = module.get_amount_out(sample_pool_state, sample_fixed_parameters, underlying, shares, input_amount)
     assert isinstance(out, int)
     assert out > 0
 
@@ -51,7 +52,7 @@ def test_get_amount_out_shares_to_underlying(sample_tokens, sample_pool_state, s
     underlying, shares = sample_tokens
     module = YoProtocolLiquidityModule()
     input_amount = 10 * 10**18
-    out, _ = module.get_amount_out(sample_pool_state, sample_fixed_parameters, shares, underlying, input_amount)
+    _, out = module.get_amount_out(sample_pool_state, sample_fixed_parameters, shares, underlying, input_amount)
     assert isinstance(out, int)
     assert out > 0
 
@@ -66,14 +67,14 @@ def test_get_amount_in_underlying_to_shares(sample_tokens, sample_pool_state, sa
     underlying, shares = sample_tokens
     module = YoProtocolLiquidityModule()
     output_amount = 10 * 10**18
-    out, _ = module.get_amount_in(sample_pool_state, sample_fixed_parameters, underlying, shares, output_amount)
+    _, out = module.get_amount_in(sample_pool_state, sample_fixed_parameters, underlying, shares, output_amount)
     assert isinstance(out, int)
 
 def test_get_amount_in_shares_to_underlying(sample_tokens, sample_pool_state, sample_fixed_parameters):
     underlying, shares = sample_tokens
     module = YoProtocolLiquidityModule()
     output_amount = 10 * 10**18
-    out, _ = module.get_amount_in(sample_pool_state, sample_fixed_parameters, shares, underlying, output_amount)
+    _, out = module.get_amount_in(sample_pool_state, sample_fixed_parameters, shares, underlying, output_amount)
     assert isinstance(out, int)
 
 def test_get_amount_in_invalid_token(sample_tokens, sample_pool_state, sample_fixed_parameters):
@@ -95,9 +96,3 @@ def test_get_tvl(sample_tokens, sample_pool_state):
     tvl = module.get_tvl(sample_pool_state, underlying)
     assert isinstance(tvl, Decimal)
     assert tvl > 0
-
-def test_get_tvl_wrong_token(sample_tokens, sample_pool_state):
-    _, shares = sample_tokens
-    module = YoProtocolLiquidityModule()
-    with pytest.raises(ValueError):
-        module.get_tvl(sample_pool_state, shares)

--- a/tests/test_yoprotocol_liquidity_module.py
+++ b/tests/test_yoprotocol_liquidity_module.py
@@ -1,0 +1,103 @@
+import pytest
+from decimal import Decimal
+from modules.yoprotocol_liquidity_module import YoProtocolLiquidityModule, Constant
+from templates.liquidity_module import Token
+
+@pytest.fixture
+def sample_tokens():
+    underlying = Token(
+        address=Constant.OPTIMISM_WETH,
+        symbol="WETH",
+        decimals=18,
+        reference_price=Decimal("1.0")
+    )
+    shares = Token(
+        address="0xSHARES",
+        symbol="yETH",
+        decimals=18,
+        reference_price=Decimal("1.0")
+    )
+    return underlying, shares
+
+@pytest.fixture
+def sample_pool_state():
+    return {
+        "totalAssets": 1000 * 10**18,
+        "totalSupply": 500 * 10**18,
+        "underlyingTokenAddress": Constant.OPTIMISM_WETH,
+        "sharesTokenAddress": "0xSHARES",
+        "currentSharePrice": str(2 * 10**18),
+        "firstSharePrice": str(1 * 10**18),
+        "uptimeDays": 10
+    }
+
+@pytest.fixture
+def sample_fixed_parameters():
+    return {
+        "decimals": 18,
+        "underlyingTokenAddress": Constant.OPTIMISM_WETH,
+        "sharesTokenAddress": "0xSHARES"
+    }
+
+def test_get_amount_out_underlying_to_shares(sample_tokens, sample_pool_state, sample_fixed_parameters):
+    underlying, shares = sample_tokens
+    module = YoProtocolLiquidityModule()
+    input_amount = 10 * 10**18
+    out, _ = module.get_amount_out(sample_pool_state, sample_fixed_parameters, underlying, shares, input_amount)
+    assert isinstance(out, int)
+    assert out > 0
+
+def test_get_amount_out_shares_to_underlying(sample_tokens, sample_pool_state, sample_fixed_parameters):
+    underlying, shares = sample_tokens
+    module = YoProtocolLiquidityModule()
+    input_amount = 10 * 10**18
+    out, _ = module.get_amount_out(sample_pool_state, sample_fixed_parameters, shares, underlying, input_amount)
+    assert isinstance(out, int)
+    assert out > 0
+
+def test_get_amount_out_invalid_token(sample_tokens, sample_pool_state, sample_fixed_parameters):
+    underlying, shares = sample_tokens
+    module = YoProtocolLiquidityModule()
+    fake_token = Token(address="0xBAD", symbol="BAD", decimals=18, reference_price=Decimal("1.0"))
+    with pytest.raises(ValueError):
+        module.get_amount_out(sample_pool_state, sample_fixed_parameters, fake_token, shares, 1)
+
+def test_get_amount_in_underlying_to_shares(sample_tokens, sample_pool_state, sample_fixed_parameters):
+    underlying, shares = sample_tokens
+    module = YoProtocolLiquidityModule()
+    output_amount = 10 * 10**18
+    out, _ = module.get_amount_in(sample_pool_state, sample_fixed_parameters, underlying, shares, output_amount)
+    assert isinstance(out, int)
+
+def test_get_amount_in_shares_to_underlying(sample_tokens, sample_pool_state, sample_fixed_parameters):
+    underlying, shares = sample_tokens
+    module = YoProtocolLiquidityModule()
+    output_amount = 10 * 10**18
+    out, _ = module.get_amount_in(sample_pool_state, sample_fixed_parameters, shares, underlying, output_amount)
+    assert isinstance(out, int)
+
+def test_get_amount_in_invalid_token(sample_tokens, sample_pool_state, sample_fixed_parameters):
+    underlying, shares = sample_tokens
+    module = YoProtocolLiquidityModule()
+    fake_token = Token(address="0xBAD", symbol="BAD", decimals=18, reference_price=Decimal("1.0"))
+    with pytest.raises(ValueError):
+        module.get_amount_in(sample_pool_state, sample_fixed_parameters, fake_token, shares, 1)
+
+def test_get_apy(sample_pool_state):
+    module = YoProtocolLiquidityModule()
+    apy = module.get_apy(sample_pool_state)
+    assert isinstance(apy, Decimal)
+    assert apy > 0
+
+def test_get_tvl(sample_tokens, sample_pool_state):
+    underlying, _ = sample_tokens
+    module = YoProtocolLiquidityModule()
+    tvl = module.get_tvl(sample_pool_state, underlying)
+    assert isinstance(tvl, Decimal)
+    assert tvl > 0
+
+def test_get_tvl_wrong_token(sample_tokens, sample_pool_state):
+    _, shares = sample_tokens
+    module = YoProtocolLiquidityModule()
+    with pytest.raises(ValueError):
+        module.get_tvl(sample_pool_state, shares)


### PR DESCRIPTION
## Protocol Information
- **Protocol Name:** Yo Protocol
- **Protocol Website:** https://docs.yo.xyz/
- **Indexing Smart Contract Addresses (e.g. factories):**  
  - Base
    - yoETH vault - 0x3a43aec53490cb9fa922847385d82fe25d0e9de7
    - yoBTC vault - 0xbCbc8cb4D1e8ED048a6276a5E94A3e952660BcbC
    - yoUSD vault - 0x0000000f2eB9f69274678c76222B35eEc7588a65

---

## Summary of Integration  
Provide a brief overview of your integration:  
YO stands for Yield Optimizer. YO is a DeFi protocol that helps you easily boost your crypto earnings without the hassle. YO automatically moves funds across the best-performing pools no matter the blockchain, so you’re always getting the highest risk-adjusted yield. 

YO leverages Exponential.fi's Risk Ratings to smartly balance risks and reward—so you don’t have to spend time managing risk yourself. YO is fully decentralized, meaning you’re always in control of your assets from your own wallet. If you want a simple, secure way to earn more from your crypto, YO’s got you covered.

*Obtained from https://docs.yo.xyz/*

---

## Implementation Details  
### Execution Functions Required  
```solidity
interface IVault {
  function deposit(uint256 assets, address receiver) external returns (uint256);
  function requestRedeem(uint256 shares, address receiver, address owner) external returns (uint256);
}
```

### Functions Implemented  
- `get_amount_in()`: Returns the amount of underlying asset required to transfer to get output_amount shares in Ether denomination. (using OZ ERC4626 convertToAssets function)
- `get_amount_out()`: Returns the amount of underlying asset received from input_amount of shares in Ether denomination. (using OZ ERC4626 convertToShares function)
- `get_apy()`: (currentSharePrice - originSharePrice) / Constant.ETHER / days * Decimal(365) * Decimal(100)
- `get_tvl()`: From GlueX data

### Dynamic States Required for AMM Calculations  
Specify any on-chain values that change frequently and are required for accurate AMM computations, such as:  
- Current total supply
- Current total assets
- currentSharePrice
- originSharePrice
- N of days between originSharePrice and currentSharePrice

### Static States Required for AMM Calculations  
Specify any on-chain values that remain constant such as:  
- vaultContractAddress
- underlyingTokenAddress
- shareTokenDecimals

### Dependencies  
**N/A**

### Other Requirements  
**N/A**

---

## Test Results  
<details><summary>Details</summary>

```sh
(venv) hanz@debian:~/Work/Bounty/liquidity-module-self-integration$ py -m pytest -v
=========================================================================================================== test session starts ============================================================================================================
platform linux -- Python 3.13.2, pytest-8.3.5, pluggy-1.6.0 -- /home/hanz/Work/Bounty/liquidity-module-self-integration/venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/hanz/Work/Bounty/liquidity-module-self-integration
collected 8 items                                                                                                                                                                                                                          

tests/test_yoprotocol_liquidity_module.py::test_get_amount_out_underlying_to_shares PASSED                                                                                                                                           [ 12%]
tests/test_yoprotocol_liquidity_module.py::test_get_amount_out_shares_to_underlying PASSED                                                                                                                                           [ 25%]
tests/test_yoprotocol_liquidity_module.py::test_get_amount_out_invalid_token PASSED                                                                                                                                                  [ 37%]
tests/test_yoprotocol_liquidity_module.py::test_get_amount_in_underlying_to_shares PASSED                                                                                                                                            [ 50%]
tests/test_yoprotocol_liquidity_module.py::test_get_amount_in_shares_to_underlying PASSED                                                                                                                                            [ 62%]
tests/test_yoprotocol_liquidity_module.py::test_get_amount_in_invalid_token PASSED                                                                                                                                                   [ 75%]
tests/test_yoprotocol_liquidity_module.py::test_get_apy PASSED                                                                                                                                                                       [ 87%]
tests/test_yoprotocol_liquidity_module.py::test_get_tvl PASSED                                                                                                                                                                       [100%]

============================================================================================================ 8 passed in 0.01s =============================================================================================================
```

</details>