### PR TITLE
Add Noon

### DIFF
--- a/modules/noon_liquidity_module.py
+++ b/modules/noon_liquidity_module.py
@@ -41,5 +41,25 @@ class MyProtocolLiquidityModule(LiquidityModule):
         fixed_parameters: Dict,
         pool_tokens: Dict[Token.address, Token]
     ) -> int:
-        # USN + sUSN in sUSN contract
-        pass
+        # USN total supply
+        # ethereum: {
+        #     usn: '0xdA67B4284609d2d48e5d10cfAc411572727dc1eD',
+        #     susn: '0xE24a3DC889621612422A64E6388927901608B91D',
+        # },
+        # sophon: {
+        #     usn: '0xC1AA99c3881B26901aF70738A7C217dc32536d36',
+        #     susn: '0xb87dbe27db932bacaaa96478443b6519d52c5004',
+        # },
+        # era: {
+        #     usn: '0x0469d9d1dE0ee58fA1153ef00836B9BbCb84c0B6',
+        #     susn: '0xB6a09d426861c63722Aa0b333a9cE5d5a9B04c4f',
+        # }
+        
+        usn_amount = pool_state.get('totalSupply', 0)
+        usn_address = fixed_parameters.get('usn_address')
+        price = pool_tokens[usn_address].reference_price
+
+        tvl = usn_amount * price
+        tvl /= 10 ** pool_tokens[usn_address].decimals
+
+        return tvl

--- a/modules/noon_liquidity_module.py
+++ b/modules/noon_liquidity_module.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 class MyProtocolLiquidityModule(LiquidityModule):
     def get_amount_out(
         self, 
-        pool_states: Dict, 
+        pool_state: Dict, 
         fixed_parameters: Dict,
         input_token: Token, 
         output_token: Token,
@@ -25,10 +25,21 @@ class MyProtocolLiquidityModule(LiquidityModule):
         # Only staking is atomic
         pass
 
-    def get_apy(self, pool_state: Dict) -> Decimal:
+    def get_apy(
+		self, 
+		pool_state: Dict, 
+		underlying_amount:int,
+		underlying_token:Token, 
+		pool_tokens: Dict[Token.address, Token]
+    ) -> int:
         # 1 USN/sUSN price disrepancy between `days` compounded everyday for 365 days
         pass
 
-    def get_tvl(self, pool_state: Dict, token: Optional[Token] = None) -> Decimal:
+    def get_tvl(
+        self, 
+        pool_state: Dict,
+        fixed_parameters: Dict,
+        pool_tokens: Dict[Token.address, Token]
+    ) -> int:
         # USN + sUSN in sUSN contract
         pass

--- a/modules/noon_liquidity_module.py
+++ b/modules/noon_liquidity_module.py
@@ -15,6 +15,18 @@ class NoonLiquidityModule(LiquidityModule):
         offset = 10 ** decimal_offset
         
         return math.floor(assets * (total_supply + offset) / (total_assets + 1))
+    
+    def _convert_to_assets(
+        self,
+        pool_state: Dict,
+        shares: int
+    ) -> int:
+        total_supply = pool_state.get('totalSupply', 0)
+        total_assets = pool_state.get('totalAssets', 0)
+        decimal_offset = 0
+        offset = 10 ** decimal_offset
+        
+        return math.floor(shares * (total_assets + 1) / (total_supply + offset))
 
     def get_amount_out(
         self, 
@@ -24,8 +36,17 @@ class NoonLiquidityModule(LiquidityModule):
         output_token: Token,
         input_amount: int, 
     ) -> tuple[int | None, int | None]:
-        # Only staking is atomic
-        pass
+        usn_address = fixed_parameters.get('usn_address')
+        susn_address = fixed_parameters.get('susn_address')
+
+        if input_token.address != usn_address or output_token.address != susn_address:
+            return None, None
+        
+        output_amount = self._convert_to_shares(
+            pool_state,
+            input_amount
+        )
+        return output_amount, None
 
     def get_amount_in(
         self, 
@@ -35,8 +56,17 @@ class NoonLiquidityModule(LiquidityModule):
         output_token: Token,
         output_amount: int
     ) -> tuple[int | None, int | None]:
-        # Only staking is atomic
-        pass
+        usn_address = fixed_parameters.get('usn_address')
+        susn_address = fixed_parameters.get('susn_address')
+
+        if input_token.address != usn_address or output_token.address != susn_address:
+            return None, None
+        
+        input_amount = self._convert_to_assets(
+            pool_state,
+            output_amount
+        )
+        return input_amount, None
 
     def get_apy(
 		self, 

--- a/modules/noon_liquidity_module.py
+++ b/modules/noon_liquidity_module.py
@@ -95,26 +95,25 @@ class NoonLiquidityModule(LiquidityModule):
             return 0
         
         # Dillute the current state
-        current_pool_state['totalAssets'] += underlying_amount
-        current_pool_state['totalSupply'] += self._convert_to_shares(
+        shares = self._convert_to_shares(
             current_pool_state,
             underlying_amount
         )
+        current_pool_state['totalAssets'] += underlying_amount
+        current_pool_state['totalSupply'] += shares
 
         # Calculate price disrepancy
-        previous_price = self._convert_to_shares(
+        previous_price = self._convert_to_assets(
             previous_pool_state,
-            underlying_amount
+            shares
         )
 
-        current_price = self._convert_to_shares(
+        current_price = self._convert_to_assets(
             current_pool_state,
-            underlying_amount
+            shares
         )
 
-        d_price = previous_price - current_price # lower sUSN/USN price means profit
-        daily_apy = d_price / previous_price / days
-
+        daily_apy = current_price / previous_price / days
         compounded_apy = (1 + daily_apy) ** 365 - 1
         apy_bps = compounded_apy * 10000
 

--- a/modules/noon_liquidity_module.py
+++ b/modules/noon_liquidity_module.py
@@ -1,8 +1,21 @@
+import math
 from templates.liquidity_module import LiquidityModule, Token
 from typing import Dict, Optional
 from decimal import Decimal
 
-class MyProtocolLiquidityModule(LiquidityModule):
+class NoonLiquidityModule(LiquidityModule):
+    def _convert_to_shares(
+        self,
+        pool_state: Dict,
+        assets: int
+    ) -> int:
+        total_supply = pool_state.get('totalSupply', 0)
+        total_assets = pool_state.get('totalAssets', 0)
+        decimal_offset = 0
+        offset = 10 ** decimal_offset
+        
+        return math.floor(assets * (total_supply + offset) / (total_assets + 1))
+
     def get_amount_out(
         self, 
         pool_state: Dict, 
@@ -27,13 +40,56 @@ class MyProtocolLiquidityModule(LiquidityModule):
 
     def get_apy(
 		self, 
-		pool_state: Dict, 
+		pool_state: Dict,
 		underlying_amount:int,
 		underlying_token:Token, 
 		pool_tokens: Dict[Token.address, Token]
     ) -> int:
-        # 1 USN/sUSN price disrepancy between `days` compounded everyday for 365 days
-        pass
+        # 1 sUSN/USN price disrepancy between `days` compounded everyday for 365 days
+        usn_address = underlying_token.address
+        asset_decimals = pool_tokens[usn_address].decimals
+        days = pool_state.get('days', 0)
+        # Previous state
+        previous_total_assets = pool_state.get('prevTotalAssets', 0)
+        previous_total_supply = pool_state.get('prevTotalSupply', 0)
+        previous_pool_state = {
+            'totalAssets': previous_total_assets,
+            'totalSupply': previous_total_supply
+        }
+        # Current state
+        current_pool_state = {
+            'totalAssets': pool_state.get('totalAssets', 0),
+            'totalSupply': pool_state.get('totalSupply', 0)
+        }
+
+        if days == 0:
+            return 0
+        
+        # Dillute the current state
+        current_pool_state['totalAssets'] += underlying_amount
+        current_pool_state['totalSupply'] += self._convert_to_shares(
+            current_pool_state,
+            underlying_amount
+        )
+
+        # Calculate price disrepancy
+        previous_price = self._convert_to_shares(
+            previous_pool_state,
+            underlying_amount
+        )
+
+        current_price = self._convert_to_shares(
+            current_pool_state,
+            underlying_amount
+        )
+
+        d_price = current_price - previous_price
+        daily_apy = d_price / days
+
+        compounded_apy = (1 + daily_apy) ** 365 - 1
+        apy_bps = compounded_apy * 10000
+
+        return int(apy_bps)
 
     def get_tvl(
         self, 
@@ -54,7 +110,7 @@ class MyProtocolLiquidityModule(LiquidityModule):
         #     usn: '0x0469d9d1dE0ee58fA1153ef00836B9BbCb84c0B6',
         #     susn: '0xB6a09d426861c63722Aa0b333a9cE5d5a9B04c4f',
         # }
-        
+
         usn_amount = pool_state.get('totalSupply', 0)
         usn_address = fixed_parameters.get('usn_address')
         price = pool_tokens[usn_address].reference_price

--- a/modules/noon_liquidity_module.py
+++ b/modules/noon_liquidity_module.py
@@ -11,7 +11,7 @@ class MyProtocolLiquidityModule(LiquidityModule):
         output_token: Token,
         input_amount: int, 
     ) -> tuple[int | None, int | None]:
-        # Implement logic to calculate output amount given input amount
+        # Only staking is atomic
         pass
 
     def get_amount_in(
@@ -22,13 +22,13 @@ class MyProtocolLiquidityModule(LiquidityModule):
         output_token: Token,
         output_amount: int
     ) -> tuple[int | None, int | None]:
-        # Implement logic to calculate required input amount given output amount
+        # Only staking is atomic
         pass
 
     def get_apy(self, pool_state: Dict) -> Decimal:
-        # Implement APY calculation logic
+        # 1 USN/sUSN price disrepancy between `days` compounded everyday for 365 days
         pass
 
     def get_tvl(self, pool_state: Dict, token: Optional[Token] = None) -> Decimal:
-        # Implement TVL calculation logic
+        # USN + sUSN in sUSN contract
         pass

--- a/modules/noon_liquidity_module.py
+++ b/modules/noon_liquidity_module.py
@@ -1,0 +1,34 @@
+from templates.liquidity_module import LiquidityModule, Token
+from typing import Dict, Optional
+from decimal import Decimal
+
+class MyProtocolLiquidityModule(LiquidityModule):
+    def get_amount_out(
+        self, 
+        pool_states: Dict, 
+        fixed_parameters: Dict,
+        input_token: Token, 
+        output_token: Token,
+        input_amount: int, 
+    ) -> tuple[int | None, int | None]:
+        # Implement logic to calculate output amount given input amount
+        pass
+
+    def get_amount_in(
+        self, 
+        pool_state: Dict, 
+        fixed_parameters: Dict,
+        input_token: Token,
+        output_token: Token,
+        output_amount: int
+    ) -> tuple[int | None, int | None]:
+        # Implement logic to calculate required input amount given output amount
+        pass
+
+    def get_apy(self, pool_state: Dict) -> Decimal:
+        # Implement APY calculation logic
+        pass
+
+    def get_tvl(self, pool_state: Dict, token: Optional[Token] = None) -> Decimal:
+        # Implement TVL calculation logic
+        pass

--- a/tests/testnoon_liquidity_module.py
+++ b/tests/testnoon_liquidity_module.py
@@ -1,0 +1,118 @@
+import pytest
+from decimal import Decimal
+from modules.noon_liquidity_module import NoonLiquidityModule
+from templates.liquidity_module import Token
+
+@pytest.fixture
+def noon_module():
+    return NoonLiquidityModule()
+
+@pytest.fixture
+def tokens():
+    usn = Token(address="0xUSN", symbol="USN", decimals=18, reference_price=Decimal("1.0"))
+    susn = Token(address="0xSUSN", symbol="sUSN", decimals=18, reference_price=Decimal("1.0"))
+    return {usn.address: usn, susn.address: susn}
+
+@pytest.fixture
+def fixed_parameters(tokens):
+    return {"usn_address": tokens["0xUSN"].address, "susn_address": tokens["0xSUSN"].address}
+
+# --- get_amount_out ---
+def test_get_amount_out_general(noon_module, tokens, fixed_parameters):
+    pool_state = {"totalSupply": 1000, "totalAssets": 2000}
+    input_amount = 500
+    out, fee = noon_module.get_amount_out(
+        pool_state, fixed_parameters, tokens["0xUSN"], tokens["0xSUSN"], input_amount
+    )
+    assert isinstance(out, int)
+    assert fee is None
+
+def test_get_amount_out_exact(noon_module, tokens, fixed_parameters):
+    pool_state = {"totalSupply": 1000, "totalAssets": 2000}
+    input_amount = 100
+    # output = floor(100 * (1000+1)/(2000+1)) = floor(100*1001/2001)
+    expected = (100*1001)//2001
+    out, fee = noon_module.get_amount_out(
+        pool_state, fixed_parameters, tokens["0xUSN"], tokens["0xSUSN"], input_amount
+    )
+    assert out == expected
+    assert fee is None
+
+def test_get_amount_out_wrong_tokens(noon_module, tokens, fixed_parameters):
+    pool_state = {"totalSupply": 1000, "totalAssets": 2000}
+    out, fee = noon_module.get_amount_out(
+        pool_state, fixed_parameters, tokens["0xSUSN"], tokens["0xUSN"], 100
+    )
+    assert out is None and fee is None
+
+# --- get_amount_in ---
+def test_get_amount_in_general(noon_module, tokens, fixed_parameters):
+    pool_state = {"totalSupply": 1000, "totalAssets": 2000}
+    output_amount = 100
+    inp, fee = noon_module.get_amount_in(
+        pool_state, fixed_parameters, tokens["0xUSN"], tokens["0xSUSN"], output_amount
+    )
+    assert isinstance(inp, int)
+    assert fee is None
+
+def test_get_amount_in_exact(noon_module, tokens, fixed_parameters):
+    pool_state = {"totalSupply": 1000, "totalAssets": 2000}
+    output_amount = 100
+    # input = floor(100 * (2000+1)/(1000+1))
+    expected = (100*2001)//1001
+    inp, fee = noon_module.get_amount_in(
+        pool_state, fixed_parameters, tokens["0xUSN"], tokens["0xSUSN"], output_amount
+    )
+    assert inp == expected
+    assert fee is None
+
+def test_get_amount_in_wrong_tokens(noon_module, tokens, fixed_parameters):
+    pool_state = {"totalSupply": 1000, "totalAssets": 2000}
+    inp, fee = noon_module.get_amount_in(
+        pool_state, fixed_parameters, tokens["0xSUSN"], tokens["0xUSN"], 100
+    )
+    assert inp is None and fee is None
+
+# --- get_apy ---
+def test_get_apy_zero_days(noon_module, tokens):
+    pool_state = {"days": 0}
+    apy = noon_module.get_apy(pool_state, 1000, tokens["0xUSN"], tokens)
+    assert apy == 0
+
+def test_get_apy_compound(noon_module, tokens):
+    pool_state = {
+        "days": 10,
+        "prevTotalAssets": 10000,
+        "prevTotalSupply": 10000,
+        "totalAssets": 12000,
+        "totalSupply": 12000,
+    }
+    # This is a general test, just check int output
+    apy = noon_module.get_apy(pool_state, 1000, tokens["0xUSN"], tokens)
+    assert isinstance(apy, int)
+    assert apy > 0
+
+def test_get_apy_exact(noon_module, tokens):
+    pool_state = {
+        "days": 1,
+        "prevTotalAssets": 1e18,
+        "prevTotalSupply": 1e18,
+        "totalAssets": 2e18,
+        "totalSupply": 2e18,
+    }
+    apy = noon_module.get_apy(pool_state, 1e18, tokens["0xUSN"], tokens)
+    assert apy != 2**365 * 10000 - 1 # Must be dilluted
+    assert apy == 502902801166828306432
+
+# --- get_tvl ---
+def test_get_tvl_general(noon_module, tokens, fixed_parameters):
+    pool_state = {"totalSupply": 1e18}
+    tvl = noon_module.get_tvl(pool_state, fixed_parameters, tokens)
+    assert isinstance(tvl, int)
+    assert tvl > 0
+
+def test_get_tvl_exact(noon_module, tokens, fixed_parameters):
+    pool_state = {"totalSupply": 1e18}
+    # price = 1.0, decimals = 18, so tvl = 1e18 * 1.0 / 1e18 = 1.0
+    tvl = noon_module.get_tvl(pool_state, fixed_parameters, tokens)
+    assert tvl == 1.0

--- a/tests/testnoon_liquidity_module.py
+++ b/tests/testnoon_liquidity_module.py
@@ -94,15 +94,15 @@ def test_get_apy_compound(noon_module, tokens):
 
 def test_get_apy_exact(noon_module, tokens):
     pool_state = {
-        "days": 1,
+        "days": 365,
         "prevTotalAssets": 1e18,
         "prevTotalSupply": 1e18,
         "totalAssets": 2e18,
         "totalSupply": 2e18,
     }
     apy = noon_module.get_apy(pool_state, 1e18, tokens["0xUSN"], tokens)
-    assert apy != 2**365 * 10000 - 1 # Must be dilluted
-    assert apy == 502902801166828306432
+    assert apy != 2 * 10000 - 1 # Must be dilluted
+    assert apy == int(((1 + 1/365) ** 365 - 1) * 10000)
 
 # --- get_tvl ---
 def test_get_tvl_general(noon_module, tokens, fixed_parameters):


### PR DESCRIPTION
## Protocol Information  
- **Protocol Name:** Noon
- **Protocol Website:** https://docs.noon.capital/
- **Indexing Smart Contract Addresses (e.g. factories):**  
  - Ethereum
    - 0xdA67B4284609d2d48e5d10cfAc411572727dc1eD, USN
    - 0xE24a3DC889621612422A64E6388927901608B91D, sUSN
  - Sophon
    - 0xC1AA99c3881B26901aF70738A7C217dc32536d36, USN
    - 0xb87dbe27db932bacaaa96478443b6519d52c5004, SUSN
  - ZKSync Era
    - 0x0469d9d1dE0ee58fA1153ef00836B9BbCb84c0B6, USN
    - 0xB6a09d426861c63722Aa0b333a9cE5d5a9B04c4f, SUSN

## Summary of Integration  
Provide a brief overview of your integration:  
- What does your protocol do?
  - Noon aims to be the most intelligent and fair yield-generating stablecoin in web3
- What type of liquidity does it provide (DEX, lending, yield farming, etc.)?
  - Stablecoin
  - Yield Farming
- Any unique features that GlueX should consider?
  - n/a

---

## Implementation Details  
### Execution Functions Required  
```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.0;

interface StakingVaultOFTUpgradeableHyperlane {
    function deposit(uint256 assets, address receiver) external returns (uint256);
    function depositWithPermit(uint256 assets, address receiver, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
        external
        returns (uint256);
    function depositWithSlippageCheck(uint256 assets, address receiver, uint256 minSharesOut)
        external
        returns (uint256);
}
```

### Functions Implemented  
- `get_amount_out()`: Only use this with sUSN contract `pool_state`
- `get_amount_in()`: Only use this with sUSN contract `pool_state`
- `get_apy()`: Only use this with sUSN contract `pool_state`
- `get_tvl()`: Only use this with USN ERC20 `pool_state`

### Dynamic States Required for AMM Calculations  
 - `totalSupply` - USN or sUSN ERC20 total supply
 - `totalAssets` - Underlying ERC20 on sUSN contract
 - `prevTotalAssets` - Previous N days totalAssets on sUSN contract
 - `prevTotalSupply` - Previous N days totalSupply on sUSN contract
 - `days` - Number of days between prev and current states

### Static States Required for AMM Calculations  
 - `usn_address` - USN address on current chain
 - `susn_address` - sUSN address on current chain

### Dependencies  
N/A

### Other Requirements  
- **API Keys:** n/a
- **Special Access Requirements:** n/a

---

## Test Results  
<details>
<summary>Click to view test results</summary>


```sh
(venv) hanz@debian:~/Work/Bounty/liquidity-module-self-integration$ py -m pytest ./tests/testnoon_liquidity_module.py --cov -v
=========================================================================================================== test session starts ============================================================================================================
platform linux -- Python 3.13.2, pytest-8.3.5, pluggy-1.6.0 -- /home/hanz/Work/Bounty/liquidity-module-self-integration/venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/hanz/Work/Bounty/liquidity-module-self-integration
plugins: cov-6.1.1
collected 11 items                                                                                                                                                                                                                         

tests/testnoon_liquidity_module.py::test_get_amount_out_general PASSED                                                                                                                                                               [  9%]
tests/testnoon_liquidity_module.py::test_get_amount_out_exact PASSED                                                                                                                                                                 [ 18%]
tests/testnoon_liquidity_module.py::test_get_amount_out_wrong_tokens PASSED                                                                                                                                                          [ 27%]
tests/testnoon_liquidity_module.py::test_get_amount_in_general PASSED                                                                                                                                                                [ 36%]
tests/testnoon_liquidity_module.py::test_get_amount_in_exact PASSED                                                                                                                                                                  [ 45%]
tests/testnoon_liquidity_module.py::test_get_amount_in_wrong_tokens PASSED                                                                                                                                                           [ 54%]
tests/testnoon_liquidity_module.py::test_get_apy_zero_days PASSED                                                                                                                                                                    [ 63%]
tests/testnoon_liquidity_module.py::test_get_apy_compound PASSED                                                                                                                                                                     [ 72%]
tests/testnoon_liquidity_module.py::test_get_apy_exact PASSED                                                                                                                                                                        [ 81%]
tests/testnoon_liquidity_module.py::test_get_tvl_general PASSED                                                                                                                                                                      [ 90%]
tests/testnoon_liquidity_module.py::test_get_tvl_exact PASSED                                                                                                                                                                        [100%]

============================================================================================================== tests coverage ==============================================================================================================
_____________________________________________________________________________________________ coverage: platform linux, python 3.13.2-final-0 ______________________________________________________________________________________________

Name                                 Stmts   Miss  Cover
--------------------------------------------------------
modules/noon_liquidity_module.py        56      0   100%
templates/liquidity_module.py           22      4    82%
tests/testnoon_liquidity_module.py      72      0   100%
--------------------------------------------------------
TOTAL                                  150      4    97%
============================================================================================================ 11 passed in 0.10s ============================================================================================================
```

</details>